### PR TITLE
Add city and state to course data

### DIFF
--- a/interbay_golf_links.json
+++ b/interbay_golf_links.json
@@ -4,56 +4,59 @@
     {
       "hole": 1,
       "par": 4,
-      "latitude": 47.6412282,
-      "longitude": -122.3797227
+      "latitude": 47.6427898,
+      "longitude": -122.3789331
     },
     {
       "hole": 2,
       "par": 3,
-      "latitude": 47.6418227,
-      "longitude": -122.3793364
+      "latitude": 47.6420497,
+      "longitude": -122.3781008
     },
     {
       "hole": 3,
       "par": 3,
-      "latitude": 47.6424172,
-      "longitude": -122.3789501
+      "latitude": 47.6431391,
+      "longitude": -122.3777314
     },
     {
       "hole": 4,
       "par": 3,
-      "latitude": 47.6430116,
-      "longitude": -122.3785639
+      "latitude": 47.6421519,
+      "longitude": -122.3772926
     },
     {
       "hole": 5,
       "par": 3,
-      "latitude": 47.6436061,
-      "longitude": -122.3781776
+      "latitude": 47.641146,
+      "longitude": -122.3786225
     },
     {
       "hole": 6,
       "par": 3,
-      "latitude": 47.6442006,
-      "longitude": -122.3777913
+      "latitude": 47.6423732,
+      "longitude": -122.3797
     },
     {
       "hole": 7,
       "par": 3,
-      "latitude": 47.644795,
-      "longitude": -122.3774051
+      "latitude": 47.6441518,
+      "longitude": -122.3796234
     },
     {
       "hole": 8,
       "par": 3,
-      "latitude": 47.6453895,
-      "longitude": -122.3770188
+      "latitude": 47.645613,
+      "longitude": -122.3796257
     },
     {
       "hole": 9,
       "par": 3,
-      "latitude": 47.645984,
-      "longitude": -122.3766325
+      "latitude": 47.6456726,
+      "longitude": -122.3789295
     }
-  ]
+  ],
+  "city": "Seattle",
+  "state": "WA"
 }
+

--- a/jackson_park_golf_course.json
+++ b/jackson_park_golf_course.json
@@ -4,110 +4,113 @@
     {
       "hole": 1,
       "par": 5,
-      "latitude": 47.725134,
-      "longitude": -122.3231124
+      "latitude": 47.7264878,
+      "longitude": -122.3190965
     },
     {
       "hole": 2,
       "par": 3,
-      "latitude": 47.7256378,
-      "longitude": -122.3225197
+      "latitude": 47.7252633,
+      "longitude": -122.3223693
     },
     {
       "hole": 3,
       "par": 4,
-      "latitude": 47.7261416,
-      "longitude": -122.3219269
+      "latitude": 47.7270364,
+      "longitude": -122.3227729
     },
     {
       "hole": 4,
       "par": 4,
-      "latitude": 47.7266454,
-      "longitude": -122.3213342
+      "latitude": 47.7294958,
+      "longitude": -122.3226925
     },
     {
       "hole": 5,
       "par": 5,
-      "latitude": 47.7271492,
-      "longitude": -122.3207414
+      "latitude": 47.731746,
+      "longitude": -122.3229196
     },
     {
       "hole": 6,
       "par": 4,
-      "latitude": 47.727653,
-      "longitude": -122.3201487
+      "latitude": 47.7320017,
+      "longitude": -122.3217102
     },
     {
       "hole": 7,
       "par": 3,
-      "latitude": 47.7281568,
-      "longitude": -122.3195559
+      "latitude": 47.7291335,
+      "longitude": -122.3204118
     },
     {
       "hole": 8,
       "par": 4,
-      "latitude": 47.7286606,
-      "longitude": -122.3189632
+      "latitude": 47.7296844,
+      "longitude": -122.3195755
     },
     {
       "hole": 9,
       "par": 4,
-      "latitude": 47.7291644,
-      "longitude": -122.3183704
+      "latitude": 47.7298416,
+      "longitude": -122.3187175
     },
     {
       "hole": 10,
       "par": 4,
-      "latitude": 47.7296682,
-      "longitude": -122.3177777
+      "latitude": 47.7300839,
+      "longitude": -122.3170209
     },
     {
       "hole": 11,
       "par": 3,
-      "latitude": 47.730172,
-      "longitude": -122.3171849
+      "latitude": 47.7292832,
+      "longitude": -122.3161275
     },
     {
       "hole": 12,
       "par": 5,
-      "latitude": 47.7306758,
-      "longitude": -122.3165922
+      "latitude": 47.7313616,
+      "longitude": -122.3161704
     },
     {
       "hole": 13,
       "par": 4,
-      "latitude": 47.7311796,
-      "longitude": -122.3159994
+      "latitude": 47.7329114,
+      "longitude": -122.3173755
     },
     {
       "hole": 14,
       "par": 4,
-      "latitude": 47.7316834,
-      "longitude": -122.3154067
+      "latitude": 47.7325302,
+      "longitude": -122.3184036
     },
     {
       "hole": 15,
       "par": 4,
-      "latitude": 47.7321872,
-      "longitude": -122.3148139
+      "latitude": 47.7319191,
+      "longitude": -122.3206367
     },
     {
       "hole": 16,
       "par": 4,
-      "latitude": 47.732691,
-      "longitude": -122.3142212
+      "latitude": 47.7285188,
+      "longitude": -122.3218076
     },
     {
       "hole": 17,
       "par": 5,
-      "latitude": 47.7331948,
-      "longitude": -122.3136284
+      "latitude": 47.7268212,
+      "longitude": -122.3213686
     },
     {
       "hole": 18,
       "par": 4,
-      "latitude": 47.7336986,
-      "longitude": -122.3130357
+      "latitude": 47.7268762,
+      "longitude": -122.3194988
     }
-  ]
+  ],
+  "city": "Seattle",
+  "state": "WA"
 }
+

--- a/jefferson_park_golf_course.json
+++ b/jefferson_park_golf_course.json
@@ -4,110 +4,113 @@
     {
       "hole": 1,
       "par": 3,
-      "latitude": 47.5616041,
-      "longitude": -122.3077718
+      "latitude": 47.5660852,
+      "longitude": -122.3057625
     },
     {
       "hole": 2,
       "par": 3,
-      "latitude": 47.5621898,
-      "longitude": -122.3074311
+      "latitude": 47.5633109,
+      "longitude": -122.3050903
     },
     {
       "hole": 3,
       "par": 3,
-      "latitude": 47.5627756,
-      "longitude": -122.3070903
+      "latitude": 47.5617247,
+      "longitude": -122.3036899
     },
     {
       "hole": 4,
       "par": 4,
-      "latitude": 47.5633614,
-      "longitude": -122.3067495
+      "latitude": 47.5631434,
+      "longitude": -122.3034814
     },
     {
       "hole": 5,
       "par": 4,
-      "latitude": 47.5639471,
-      "longitude": -122.3064088
+      "latitude": 47.5641232,
+      "longitude": -122.3037191
     },
     {
       "hole": 6,
       "par": 4,
-      "latitude": 47.5645329,
-      "longitude": -122.306068
+      "latitude": 47.5640847,
+      "longitude": -122.302734
     },
     {
       "hole": 7,
       "par": 3,
-      "latitude": 47.5651187,
-      "longitude": -122.3057272
+      "latitude": 47.5662421,
+      "longitude": -122.3032265
     },
     {
       "hole": 8,
       "par": 5,
-      "latitude": 47.5657044,
-      "longitude": -122.3053865
+      "latitude": 47.5660596,
+      "longitude": -122.3040131
     },
     {
       "hole": 9,
       "par": 4,
-      "latitude": 47.5662902,
-      "longitude": -122.3050457
+      "latitude": 47.5660821,
+      "longitude": -122.3047232
     },
     {
       "hole": 10,
       "par": 4,
-      "latitude": 47.566876,
-      "longitude": -122.3047049
+      "latitude": 47.5681107,
+      "longitude": -122.3037
     },
     {
       "hole": 11,
       "par": 4,
-      "latitude": 47.5674617,
-      "longitude": -122.3043641
+      "latitude": 47.5706455,
+      "longitude": -122.3024556
     },
     {
       "hole": 12,
       "par": 3,
-      "latitude": 47.5680475,
-      "longitude": -122.3040234
+      "latitude": 47.5716472,
+      "longitude": -122.3039109
     },
     {
       "hole": 13,
       "par": 4,
-      "latitude": 47.5686333,
-      "longitude": -122.3036826
+      "latitude": 47.5698936,
+      "longitude": -122.3032324
     },
     {
       "hole": 14,
       "par": 4,
-      "latitude": 47.5692191,
-      "longitude": -122.3033418
+      "latitude": 47.5701557,
+      "longitude": -122.3046653
     },
     {
       "hole": 15,
       "par": 3,
-      "latitude": 47.5698048,
-      "longitude": -122.3030011
+      "latitude": 47.5703156,
+      "longitude": -122.3052692
     },
     {
       "hole": 16,
       "par": 4,
-      "latitude": 47.5703906,
-      "longitude": -122.3026603
+      "latitude": 47.5684439,
+      "longitude": -122.3043591
     },
     {
       "hole": 17,
       "par": 5,
-      "latitude": 47.5709764,
-      "longitude": -122.3023195
+      "latitude": 47.5697555,
+      "longitude": -122.3058054
     },
     {
       "hole": 18,
       "par": 5,
-      "latitude": 47.5715621,
-      "longitude": -122.3019788
+      "latitude": 47.5700689,
+      "longitude": -122.3071077
     }
-  ]
+  ],
+  "city": "Seattle",
+  "state": "WA"
 }
+

--- a/west_seattle_golf_course.json
+++ b/west_seattle_golf_course.json
@@ -4,110 +4,113 @@
     {
       "hole": 1,
       "par": 5,
-      "latitude": 47.5541265,
-      "longitude": -122.3741624
+      "latitude": 47.559577,
+      "longitude": -122.3717418
     },
     {
       "hole": 2,
       "par": 4,
-      "latitude": 47.5547286,
-      "longitude": -122.3737069
+      "latitude": 47.5588216,
+      "longitude": -122.3690843
     },
     {
       "hole": 3,
       "par": 3,
-      "latitude": 47.5553307,
-      "longitude": -122.3732514
+      "latitude": 47.5599139,
+      "longitude": -122.3675185
     },
     {
       "hole": 4,
       "par": 5,
-      "latitude": 47.5559329,
-      "longitude": -122.3727959
+      "latitude": 47.5577028,
+      "longitude": -122.3666604
     },
     {
       "hole": 5,
       "par": 4,
-      "latitude": 47.556535,
-      "longitude": -122.3723404
+      "latitude": 47.5570331,
+      "longitude": -122.3674199
     },
     {
       "hole": 6,
       "par": 3,
-      "latitude": 47.5571371,
-      "longitude": -122.3718849
+      "latitude": 47.5579192,
+      "longitude": -122.3683144
     },
     {
       "hole": 7,
       "par": 4,
-      "latitude": 47.5577393,
-      "longitude": -122.3714293
+      "latitude": 47.5555172,
+      "longitude": -122.3685531
     },
     {
       "hole": 8,
       "par": 4,
-      "latitude": 47.5583414,
-      "longitude": -122.3709738
+      "latitude": 47.555619,
+      "longitude": -122.3697614
     },
     {
       "hole": 9,
       "par": 5,
-      "latitude": 47.5589435,
-      "longitude": -122.3705183
+      "latitude": 47.5596482,
+      "longitude": -122.3723562
     },
     {
       "hole": 10,
       "par": 4,
-      "latitude": 47.5595457,
-      "longitude": -122.3700628
+      "latitude": 47.5605071,
+      "longitude": -122.3712149
     },
     {
       "hole": 11,
       "par": 3,
-      "latitude": 47.5601478,
-      "longitude": -122.3696073
+      "latitude": 47.5601541,
+      "longitude": -122.3688546
     },
     {
       "hole": 12,
       "par": 5,
-      "latitude": 47.5607499,
-      "longitude": -122.3691518
+      "latitude": 47.5618964,
+      "longitude": -122.3679992
     },
     {
       "hole": 13,
       "par": 3,
-      "latitude": 47.5613521,
-      "longitude": -122.3686962
+      "latitude": 47.5641975,
+      "longitude": -122.367492
     },
     {
       "hole": 14,
       "par": 4,
-      "latitude": 47.5619542,
-      "longitude": -122.3682407
+      "latitude": 47.5624021,
+      "longitude": -122.368939
     },
     {
       "hole": 15,
       "par": 4,
-      "latitude": 47.5625563,
-      "longitude": -122.3677852
+      "latitude": 47.562631,
+      "longitude": -122.3697263
     },
     {
       "hole": 16,
       "par": 4,
-      "latitude": 47.5631585,
-      "longitude": -122.3673297
+      "latitude": 47.5628872,
+      "longitude": -122.3704948
     },
     {
       "hole": 17,
       "par": 4,
-      "latitude": 47.5637606,
-      "longitude": -122.3668742
+      "latitude": 47.5629107,
+      "longitude": -122.3711263
     },
     {
       "hole": 18,
       "par": 4,
-      "latitude": 47.5643627,
-      "longitude": -122.3664187
+      "latitude": 47.563031,
+      "longitude": -122.3717111
     }
-  ]
+  ],
+  "city": "Seattle",
+  "state": "WA"
 }
+


### PR DESCRIPTION
## Summary
- add city and state fields to each Seattle municipal course
- ensure newline at end of each JSON file

## Testing
- `jq '.' interbay_golf_links.json >/dev/null`
- `jq '.' jackson_park_golf_course.json >/dev/null`
- `jq '.' jefferson_park_golf_course.json >/dev/null`
- `jq '.' west_seattle_golf_course.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68605d10d40c8325ba2d015f6132ac53