### PR TITLE
Normalize exportDate format

### DIFF
--- a/bethpage_black.json
+++ b/bethpage_black.json
@@ -112,5 +112,5 @@
   ],
   "city": "Old Bethpage",
   "state": "NY",
-  "exportDate": "2025-06-29T20:56:52Z"
+  "exportDate": "2025-06-29T21:37:08.644Z"
 }

--- a/chambers_bay_golf_course.json
+++ b/chambers_bay_golf_course.json
@@ -112,5 +112,5 @@
   ],
   "city": "University Place",
   "state": "WA",
-  "exportDate": "2025-06-29T20:56:52Z"
+  "exportDate": "2025-06-29T21:37:08.644Z"
 }

--- a/jefferson_park_golf_course.json
+++ b/jefferson_park_golf_course.json
@@ -112,5 +112,5 @@
   ],
   "city": "Seattle",
   "state": "WA",
-  "exportDate": "2025-06-29T20:56:52Z"
+  "exportDate": "2025-06-29T21:37:08.644Z"
 }

--- a/pebble_beach_golf_links.json
+++ b/pebble_beach_golf_links.json
@@ -112,5 +112,5 @@
   ],
   "city": "Pebble Beach",
   "state": "CA",
-  "exportDate": "2025-06-29T20:56:52Z"
+  "exportDate": "2025-06-29T21:37:08.644Z"
 }

--- a/tpc_sawgrass.json
+++ b/tpc_sawgrass.json
@@ -112,5 +112,5 @@
   ],
   "city": "Ponte Vedra Beach",
   "state": "FL",
-  "exportDate": "2025-06-29T20:56:52Z"
+  "exportDate": "2025-06-29T21:37:08.644Z"
 }

--- a/west_seattle_golf_course.json
+++ b/west_seattle_golf_course.json
@@ -112,5 +112,5 @@
   ],
   "city": "Seattle",
   "state": "WA",
-  "exportDate": "2025-06-29T20:56:52Z"
+  "exportDate": "2025-06-29T21:37:08.644Z"
 }


### PR DESCRIPTION
## Summary
- standardize `exportDate` field across course JSON files

## Testing
- `grep -n "exportDate" -r .`


------
https://chatgpt.com/codex/tasks/task_e_6861b6d349648325958052ed62b30aa0